### PR TITLE
Add new rule `head-req-charset-utf`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.3
+- rename `head-req-charset-utf` to `req-charset-utf`
+
 ## 1.0.2
 - removes `attr-value-style`;
 - takes the rules to the components.

--- a/rules/head-req-charset-utf/index.js
+++ b/rules/head-req-charset-utf/index.js
@@ -1,0 +1,18 @@
+const dom_utils = require("@linthtml/dom-utils");
+
+module.exports = {
+  name: "htmlacademy/head-req-charset-utf",
+  lint(node, rule_config, { report }) {
+    if (dom_utils.is_tag_node(node) && node.name === "meta") {
+      const hasUtf = node.attributes.some(attribute => attribute.value.chars.toLowerCase() === 'utf-8');
+      const hasCharset = node.attributes.some(attribute => attribute.name.chars === "charset");
+
+      if (hasCharset === true && hasUtf === false) {
+        report({
+          position: node.loc,
+          message: `"The attribute charset="" should have a value of 'utf-8'."`,
+        });
+      }
+    }
+  }
+}

--- a/rules/req-charset-utf/index.js
+++ b/rules/req-charset-utf/index.js
@@ -1,7 +1,7 @@
 const dom_utils = require("@linthtml/dom-utils");
 
 module.exports = {
-  name: "htmlacademy/head-req-charset-utf",
+  name: "htmlacademy/req-charset-utf",
   lint(node, rule_config, { report }) {
     if (dom_utils.is_tag_node(node) && node.name === "meta") {
       const hasUtf = node.attributes.some(attribute => attribute.value.chars.toLowerCase() === 'utf-8');


### PR DESCRIPTION
Для правила https://codeguide.academy/html-css.html#html-basic-parts

> Кодировка документа <meta charset="utf-8">. Кодировка символов на странице явно указана, чтобы обеспечить корректное отображение текста. Кодировка utf-8 предпочтительна.

Только нужно будет формулировку поправить с `Кодировка utf-8 предпочтительна.` на то, что работаем только с UTF-8 кодировкой