### PR TITLE
#4 adds `htmlacademy/charset-position`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
 ## 1.0.3
-- rename `head-req-charset-utf` to `req-charset-utf`
+- Rename `head-req-charset-utf` to `req-charset-utf`
 - Rename `head-req-meta` to `head-meta-charset`
 - Adds a description of the rules
+- Adds htmlacademy/charset-position
 
 ## 1.0.2
 - removes `attr-value-style`;

--- a/rules/charset-position/README.md
+++ b/rules/charset-position/README.md
@@ -1,0 +1,35 @@
+# htmlacademy/charset-position
+
+Правило позиционирование `<meta charset="">` в `<head>`. Правило принимает значения `true` или `false`
+
+## true 
+`<meta charset="">` указан первым непосредственным ребёнком в `<head>`.
+
+Проблемными считаются следующие шаблоны:
+```html
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta charset="utf-8">
+</head>
+
+<head>
+  <title>Title</title>
+  <meta charset="utf-8">
+</head>
+
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Title</title>
+  <link href="./styles/styles.css" rel="stylesheet">
+  <meta charset="utf-8">
+</head>
+```
+
+Следующие шаблоны **не** считаются проблемами:
+```html
+<head>
+  <meta charset="utf-8">
+  <title>Title</title>
+</head>
+```
+

--- a/rules/charset-position/index.js
+++ b/rules/charset-position/index.js
@@ -1,0 +1,21 @@
+const dom_utils = require("@linthtml/dom-utils");
+
+module.exports = {
+  name: "htmlacademy/charset-position",
+  lint(node, rule_config, { report }) {
+    if (dom_utils.is_tag_node(node) && node.name === "head") {
+      const childrenWithoutText = node.children.filter(children => children.type !== 'text');
+      const firstElement = childrenWithoutText[0];
+      const hasMeta = firstElement.name === 'meta';
+      const hasUtf = firstElement.attributes.some(attribute => attribute.value.chars.toLowerCase() === 'utf-8');
+      const hasCharset = firstElement.attributes.some(attribute => attribute.name.chars === "charset");
+
+      if (!hasMeta && !hasUtf && !hasCharset) {
+        report({
+          position: node.loc,
+          message: `<meta charset=""> is not the first child element in <head>`,
+        });
+      }
+    }
+  }
+}


### PR DESCRIPTION
# htmlacademy/charset-position

Правило позиционирование `<meta charset="">` в `<head>`. Правило принимает значения `true` или `false`

## true 
`<meta charset="">` указан первым непосредственным ребёнком в `<head>`.

Проблемными считаются следующие шаблоны:
```html
<head>
  <meta name="viewport" content="width=device-width, initial-scale=1">
  <meta charset="utf-8">
</head>

<head>
  <title>Title</title>
  <meta charset="utf-8">
</head>

<head>
  <meta name="viewport" content="width=device-width, initial-scale=1">
  <title>Title</title>
  <link href="./styles/styles.css" rel="stylesheet">
  <meta charset="utf-8">
</head>
```

Следующие шаблоны **не** считаются проблемами:
```html
<head>
  <meta charset="utf-8">
  <title>Title</title>
</head>
```

