### PR TITLE
Feature/img svg req dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Rename `head-req-meta` to `head-meta-charset`
 - Adds a description of the rules
 - Adds `htmlacademy/charset-position`
+- Adds `img-svg-req-dimensions`
 
 ## 1.0.2
 - removes `attr-value-style`;

--- a/rules/img-svg-req-dimensions/README.md
+++ b/rules/img-svg-req-dimensions/README.md
@@ -11,10 +11,14 @@
 <img src="images/image.jpg">
 <img width="100" src="images/image.jpg">
 <img height="100" src="images/image.jpg">
+
+<img src="images/image.jpg" width="500" height="" alt="">
+<img src="images/image.jpg" width="" height="300" alt="">
+<img src="images/image.jpg" width="" height="" alt="">
 ```
 
 ```html
-<svg width="" viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg">
   <rect x="0" y="0"></rect>
 </svg>
 
@@ -25,11 +29,15 @@
 <svg height="100" viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg">
   <rect x="0" y="0"></rect>
 </svg>
+
+<svg width="" height="" viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0"></rect>
+</svg>
 ```
 
 Следующие шаблоны **не** считаются проблемами:
 ```html
-<img src="images/image.jpg" width="500" height="300">
+<img src="images/image.jpg" width="500" height="300" alt="">
 
 <svg width="200" height="100" viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg">
   <rect x="0" y="0"></rect>

--- a/rules/img-svg-req-dimensions/README.md
+++ b/rules/img-svg-req-dimensions/README.md
@@ -1,0 +1,37 @@
+# htmlacademy/img-svg-req-dimensions
+
+Правило проверяет наличие атрибутов `width` и `height` у элементов `<img>` и `<svg>`. Правило принимает значения `true` или `false`.
+
+## true
+Элементы `<img>` и `<svg>` содержат оба атрибута `width` и `height`.
+
+Проблемными считаются следующие шаблоны:
+
+```html
+<img src="images/image.jpg">
+<img width="100" src="images/image.jpg">
+<img height="100" src="images/image.jpg">
+```
+
+```html
+<svg width="" viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0"></rect>
+</svg>
+
+<svg width="100" viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0"></rect>
+</svg>
+
+<svg height="100" viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0"></rect>
+</svg>
+```
+
+Следующие шаблоны **не** считаются проблемами:
+```html
+<img src="images/image.jpg" width="500" height="300">
+
+<svg width="200" height="100" viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0"></rect>
+</svg>
+```

--- a/rules/img-svg-req-dimensions/index.js
+++ b/rules/img-svg-req-dimensions/index.js
@@ -1,14 +1,12 @@
-const dom_utils = require("@linthtml/dom-utils");
+const {is_tag_node, has_non_empty_attribute} = require("@linthtml/dom-utils");
 
 module.exports = {
   name: "htmlacademy/img-svg-req-dimensions",
   lint(node, rule_config, { report }) {
-    if (dom_utils.is_tag_node(node) && (node.name === "img" || node.name === "svg")) {
+    if (is_tag_node(node) && (node.name === "img" || node.name === "svg")) {
       const requiredAttributes = ["width", "height"];
       const missingAttributes = requiredAttributes.filter((attribute) =>
-          !node.attributes.some(
-            (attr) => attr.name.chars === attribute
-          )
+        !has_non_empty_attribute(node, attribute)
       );
 
       if (missingAttributes.length > 0) {

--- a/rules/img-svg-req-dimensions/index.js
+++ b/rules/img-svg-req-dimensions/index.js
@@ -1,0 +1,23 @@
+const dom_utils = require("@linthtml/dom-utils");
+
+module.exports = {
+  name: "htmlacademy/img-svg-req-dimensions",
+  lint(node, rule_config, { report }) {
+    if (dom_utils.is_tag_node(node) && (node.name === "img" || node.name === "svg")) {
+      const requiredAttributes = ["width", "height"];
+      const missingAttributes = requiredAttributes.filter((attribute) =>
+          !node.attributes.some(
+            (attr) => attr.name.chars === attribute
+          )
+      );
+
+      if (missingAttributes.length > 0) {
+        const missingAttributesString = missingAttributes.join(" and ");
+        report({
+          position: node.loc,
+          message: `The <${node.name}> element is missing ${missingAttributesString} attribute(s).`,
+        });
+      }
+    }
+  },
+};


### PR DESCRIPTION
# htmlacademy/img-svg-req-dimensions

Правило проверяет наличие атрибутов `width` и `height` у элементов `<img>` и `<svg>`. Правило принимает значения `true` или `false`.

## true
Элементы `<img>` и `<svg>` содержат оба атрибута `width` и `height`.

Проблемными считаются следующие шаблоны:

```html
<img src="images/image.jpg">
<img width="100" src="images/image.jpg">
<img height="100" src="images/image.jpg">
```

```html
<svg width="" viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg">
  <rect x="0" y="0"></rect>
</svg>

<svg width="100" viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg">
  <rect x="0" y="0"></rect>
</svg>

<svg height="100" viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg">
  <rect x="0" y="0"></rect>
</svg>
```

Следующие шаблоны **не** считаются проблемами:
```html
<img src="images/image.jpg" width="500" height="300">

<svg width="200" height="100" viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg">
  <rect x="0" y="0"></rect>
</svg>
```
