### PR TITLE
Feature/a target rel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Rename `head-req-meta` to `head-meta-charset`
 - Adds a description of the rules
 - Adds `htmlacademy/charset-position`
+- Adds `a-target-rel`
 
 ## 1.0.2
 - removes `attr-value-style`;

--- a/rules/a-target-rel/README.md
+++ b/rules/a-target-rel/README.md
@@ -1,0 +1,22 @@
+# htmlacademy/a-target-rel
+Правило проверяет наличие атрибута `rel` со значениями `nofollow` и `noopener` у ссылок` <a>` с атрибутом `target="_blank"`. Правило принимает значения true или false.
+
+## true
+Ссылки `<a>` с атрибутом `target="_blank"` содержат атрибут `rel` со значениями `nofollow` и `noopener`.
+
+Проблемными считаются следующие шаблоны:
+```html
+<a href="https://htmlacademy.pro" target="_blank">Link</a>
+
+<a href="https://htmlacademy.pro" target="_blank" rel="nofollow">Link</a>
+
+<a href="https://htmlacademy.pro" target="_blank" rel="noopener">Link</a>
+```
+
+Следующие шаблоны **не** считаются проблемами:
+
+```html
+<a href="https://htmlacademy.pro" target="_blank" rel="nofollow noopener">Link</a>
+
+<a href="https://htmlacademy.pro" target="_blank" rel="noopener nofollow">Link</a>
+```

--- a/rules/a-target-rel/README.md
+++ b/rules/a-target-rel/README.md
@@ -1,14 +1,14 @@
 # htmlacademy/a-target-rel
-Правило проверяет наличие атрибута `rel` со значениями `nofollow` и `noopener` у ссылок` <a>` с атрибутом `target="_blank"`. Правило принимает значения true или false.
+Правило проверяет наличие атрибута `rel` со значениями `noreferrer` и `noopener` у ссылок` <a>` с атрибутом `target="_blank"`. Правило принимает значения true или false.
 
 ## true
-Ссылки `<a>` с атрибутом `target="_blank"` содержат атрибут `rel` со значениями `nofollow` и `noopener`.
+Ссылки `<a>` с атрибутом `target="_blank"` содержат атрибут `rel` со значениями `noreferrer` и `noopener`.
 
 Проблемными считаются следующие шаблоны:
 ```html
 <a href="https://htmlacademy.pro" target="_blank">Link</a>
 
-<a href="https://htmlacademy.pro" target="_blank" rel="nofollow">Link</a>
+<a href="https://htmlacademy.pro" target="_blank" rel="noreferrer">Link</a>
 
 <a href="https://htmlacademy.pro" target="_blank" rel="noopener">Link</a>
 ```
@@ -16,7 +16,7 @@
 Следующие шаблоны **не** считаются проблемами:
 
 ```html
-<a href="https://htmlacademy.pro" target="_blank" rel="nofollow noopener">Link</a>
+<a href="https://htmlacademy.pro" target="_blank" rel="noreferrer noopener">Link</a>
 
-<a href="https://htmlacademy.pro" target="_blank" rel="noopener nofollow">Link</a>
+<a href="https://htmlacademy.pro" target="_blank" rel="noopener noreferrer">Link</a>
 ```

--- a/rules/a-target-rel/index.js
+++ b/rules/a-target-rel/index.js
@@ -1,5 +1,14 @@
 const dom_utils = require("@linthtml/dom-utils");
+const requiredAttributes = [
+  { name: 'rel', value: 'nofollow' },
+  { name: 'rel', value: 'noopener' },
+];
 
+function isMissingAttribute(node, attribute) {
+  return !node.attributes.some((attr) => (
+    attr.name.chars === attribute.name && attr.value.chars.includes(attribute.value)
+  ));
+}
 module.exports = {
   name: "htmlacademy/a-target-rel",
   lint(node, rule_config, { report }) {

--- a/rules/a-target-rel/index.js
+++ b/rules/a-target-rel/index.js
@@ -1,5 +1,4 @@
 const { is_tag_node, attribute_has_value } = require("@linthtml/dom-utils");
-
 const requiredAttributes = {
   // todo вынести в конфиг правила
   rel: ["nofollow", "noopener"]
@@ -11,7 +10,7 @@ const isEveryValuePresent = (node, attr, values) => {
 
 const isExternalLink = (node) => {
   return is_tag_node(node) && node.name === "a" &&
-      attribute_has_value(node, 'target', '_blank')
+    attribute_has_value(node, 'target', '_blank')
 }
 
 module.exports = {
@@ -26,55 +25,6 @@ module.exports = {
           });
         }
       }
-    }
-  },
-};
-
-const requiredAttributes = [
-  { name: 'rel', value: 'nofollow' },
-  { name: 'rel', value: 'noopener' },
-];
-
-function isMissingAttribute(node, attribute) {
-  return !node.attributes.some((attr) => (
-    attr.name.chars === attribute.name && attr.value.chars.includes(attribute.value)
-  ));
-}
-module.exports = {
-  name: "htmlacademy/a-target-rel",
-  lint(node, rule_config, { report }) {
-    if (
-      dom_utils.is_tag_node(node) &&
-      node.name === "a" &&
-      node.attributes.some(
-        (attr) => attr.name.chars === "target" && attr.value.chars === "_blank"
-      )
-    ) {
-      const requiredAttributes = [
-        { name: "rel", value: "nofollow" },
-        { name: "rel", value: "noopener" },
-      ];
-      const missingAttributes = requiredAttributes.filter((attribute) =>
-        !node.attributes.some(
-          (attr) =>
-            attr.name.chars === attribute.name &&
-            attr.value.chars.includes(attribute.value)
-        )
-      );
-requiredAttributes
-        .filter((attribute) => isMissingAttribute(node, attribute))
-        .forEach((attribute) => {
-          report({
-            position: node.loc,
-            message: `The <a> element with target="_blank" is missing the "${attribute.name}=${attribute.value}" attribute.`,
-          });
-        });
-      missingAttributes.forEach((attribute) => {
-        report({
-          position: node.loc,
-          message: `The <a> element with target="_blank" is missing the "${attribute.name}=${attribute.value}" attribute.`,
-        });
-      });
     }
   },
 };

--- a/rules/a-target-rel/index.js
+++ b/rules/a-target-rel/index.js
@@ -30,7 +30,14 @@ module.exports = {
             attr.value.chars.includes(attribute.value)
         )
       );
-
+requiredAttributes
+        .filter((attribute) => isMissingAttribute(node, attribute))
+        .forEach((attribute) => {
+          report({
+            position: node.loc,
+            message: `The <a> element with target="_blank" is missing the "${attribute.name}=${attribute.value}" attribute.`,
+          });
+        });
       missingAttributes.forEach((attribute) => {
         report({
           position: node.loc,

--- a/rules/a-target-rel/index.js
+++ b/rules/a-target-rel/index.js
@@ -1,0 +1,33 @@
+const dom_utils = require("@linthtml/dom-utils");
+
+module.exports = {
+  name: "htmlacademy/a-target-rel",
+  lint(node, rule_config, { report }) {
+    if (
+      dom_utils.is_tag_node(node) &&
+      node.name === "a" &&
+      node.attributes.some(
+        (attr) => attr.name.chars === "target" && attr.value.chars === "_blank"
+      )
+    ) {
+      const requiredAttributes = [
+        { name: "rel", value: "nofollow" },
+        { name: "rel", value: "noopener" },
+      ];
+      const missingAttributes = requiredAttributes.filter((attribute) =>
+        !node.attributes.some(
+          (attr) =>
+            attr.name.chars === attribute.name &&
+            attr.value.chars.includes(attribute.value)
+        )
+      );
+
+      missingAttributes.forEach((attribute) => {
+        report({
+          position: node.loc,
+          message: `The <a> element with target="_blank" is missing the "${attribute.name}=${attribute.value}" attribute.`,
+        });
+      });
+    }
+  },
+};

--- a/rules/a-target-rel/index.js
+++ b/rules/a-target-rel/index.js
@@ -1,4 +1,35 @@
-const dom_utils = require("@linthtml/dom-utils");
+const { is_tag_node, attribute_has_value } = require("@linthtml/dom-utils");
+
+const requiredAttributes = {
+  // todo вынести в конфиг правила
+  rel: ["nofollow", "noopener"]
+};
+
+const isEveryValuePresent = (node, attr, values) => {
+  return values.every(val => attribute_has_value(node, attr, val))
+}
+
+const isExternalLink = (node) => {
+  return is_tag_node(node) && node.name === "a" &&
+      attribute_has_value(node, 'target', '_blank')
+}
+
+module.exports = {
+  name: "htmlacademy/a-target-rel",
+  lint(node, rule_config, { report }) {
+    if (isExternalLink(node)) {
+      for (const [attr, values] of Object.entries(requiredAttributes)) {
+        if (!isEveryValuePresent(node, attr, values)) {
+          report({
+            position: node.loc,
+            message: `The <a> element with target="_blank" is missing the "${attr}=${values.join(' ')}" attribute.`
+          });
+        }
+      }
+    }
+  },
+};
+
 const requiredAttributes = [
   { name: 'rel', value: 'nofollow' },
   { name: 'rel', value: 'noopener' },

--- a/rules/a-target-rel/index.js
+++ b/rules/a-target-rel/index.js
@@ -5,7 +5,7 @@ const requiredAttributes = {
 };
 
 const isEveryValuePresent = (node, attr, values) => {
-  return values.every(val => attribute_has_value(node, attr, val))
+  return values.every(val => attribute_has_value(node, attr, new RegExp(val)))
 }
 
 const isExternalLink = (node) => {

--- a/rules/a-target-rel/index.js
+++ b/rules/a-target-rel/index.js
@@ -1,7 +1,7 @@
 const { is_tag_node, attribute_has_value } = require("@linthtml/dom-utils");
 const requiredAttributes = {
   // todo вынести в конфиг правила
-  rel: ["nofollow", "noopener"]
+  rel: ["noreferrer", "noopener"]
 };
 
 const isEveryValuePresent = (node, attr, values) => {


### PR DESCRIPTION
# htmlacademy/a-target-rel
Правило проверяет наличие атрибута `rel` со значениями `nofollow` и `noopener` у ссылок` <a>` с атрибутом `target="_blank"`. Правило принимает значения true или false.

## true
Ссылки `<a>` с атрибутом `target="_blank"` содержат атрибут `rel` со значениями `nofollow` и `noopener`.

Проблемными считаются следующие шаблоны:
```html
<a href="https://htmlacademy.pro" target="_blank">Link</a>

<a href="https://htmlacademy.pro" target="_blank" rel="nofollow">Link</a>

<a href="https://htmlacademy.pro" target="_blank" rel="noopener">Link</a>
```

Следующие шаблоны **не** считаются проблемами:

```html
<a href="https://htmlacademy.pro" target="_blank" rel="nofollow noopener">Link</a>

<a href="https://htmlacademy.pro" target="_blank" rel="noopener nofollow">Link</a>
```
