### PR TITLE
Feature/form action attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Rename `head-req-meta` to `head-meta-charset`
 - Adds a description of the rules
 - Adds `htmlacademy/charset-position`
+- Adds `form-action-attribute`
 
 ## 1.0.2
 - removes `attr-value-style`;

--- a/rules/form-action-attribute/README.md
+++ b/rules/form-action-attribute/README.md
@@ -1,0 +1,17 @@
+# htmlacademy/form-action-attribute
+
+Правило проверяет расположение атрибута `action` у тега `<form>`. Правило принимает значения `true` или `false`
+
+## true
+У `<form>` должен быть заполненный атрибут `action`.
+
+Проблемными считаются следующие шаблоны:
+```html
+<form action=""></form>
+<form></form>
+```
+
+Следующие шаблоны **не** считаются проблемами:
+```html
+<form action="https://echo.htmlacademy.ru"></form>
+```

--- a/rules/form-action-attribute/index.js
+++ b/rules/form-action-attribute/index.js
@@ -1,0 +1,24 @@
+const dom_utils = require("@linthtml/dom-utils");
+
+module.exports = {
+  name: "htmlacademy/form-action-attribute",
+  lint(node, rule_config, { report }) {
+    if (dom_utils.is_tag_node(node) && node.name === "form") {
+      const actionAttribute = node.attributes.find(
+        (attr) => attr.name.chars === "action"
+      );
+
+      if (!actionAttribute) {
+        report({
+          position: node.loc,
+          message: `The <form> element is missing the "action" attribute.`,
+        });
+      } else if (actionAttribute.value === null) {
+        report({
+          position: actionAttribute.loc,
+          message: `The value of the "action" attribute for the <form> element is empty.`,
+        });
+      }
+    }
+  },
+};


### PR DESCRIPTION
# htmlacademy/form-action-attribute

Правило проверяет расположение атрибута `action` у тега `<form>`. Правило принимает значения `true` или `false`

## true
У `<form>` должен быть заполненный атрибут `action`.

Проблемными считаются следующие шаблоны:
```html
<form action=""></form>
<form></form>
```

Следующие шаблоны **не** считаются проблемами:
```html
<form action="https://echo.htmlacademy.ru"></form>
```
