### PR TITLE
Fix input-req-label

### DIFF
--- a/rules/input-req-label/README.md
+++ b/rules/input-req-label/README.md
@@ -39,4 +39,5 @@
 
 <input type="hidden" value="dinosaur">
 
+<input type="submit" value="submit">
 ```

--- a/rules/input-req-label/fixture/error.html
+++ b/rules/input-req-label/fixture/error.html
@@ -1,0 +1,5 @@
+<!-- without a value for the value attribute -->
+<input type="submit" value="">
+
+<!-- without the value attribute -->
+<input type="submit">

--- a/rules/input-req-label/fixture/success.html
+++ b/rules/input-req-label/fixture/success.html
@@ -1,0 +1,2 @@
+<!-- [type="submit"] with the specified value in the value attribute -->
+<input type="submit" value="Отправить">

--- a/rules/input-req-label/index.js
+++ b/rules/input-req-label/index.js
@@ -28,6 +28,7 @@ module.exports = {
     if (!is_tag_node(node) || !['input', 'label'].includes(node.name)) {
       return;
     }
+
     // if it's a label with a 'for', store that value
     if (node.name === 'label') {
       const for_attribute = attribute_value(node, 'for');
@@ -37,11 +38,10 @@ module.exports = {
       return;
     }
 
-    if (attribute_has_value(node, 'type', 'hidden')) {
-      return;
-    }
+    const isHiddenOrSubmitType = (input) => ['hidden', 'submit'].some((type) => attribute_has_value(input, 'type', type));
+    const hasAriaLabel = has_non_empty_attribute(node, 'aria-label');
 
-    if (has_non_empty_attribute(node, 'aria-label')) {
+    if (isHiddenOrSubmitType(node) || hasAriaLabel) {
       return;
     }
 


### PR DESCRIPTION
Excludes the `<input type="submit">` check from the input-req-label rule.