### PR TITLE
Fix tag-req-attr

### DIFF
--- a/rules/tag-req-attr/README.md
+++ b/rules/tag-req-attr/README.md
@@ -63,15 +63,15 @@
 
 ```json
 'htmlacademy/tag-req-attr': [
-  'ignore', {
-    'input': [
-      {
-        name: 'name',
-        ignore: {
-          type: 'submit'
-        }
-      },
-    ],
+  true,
+  'input': [
+    {
+      name: 'name',
+      ignore: {
+        type: 'submit'
+      }
+    },
+  ],
 ]
 ```
 

--- a/rules/tag-req-attr/README.md
+++ b/rules/tag-req-attr/README.md
@@ -4,17 +4,14 @@
 
 Форк: https://linthtml.vercel.app/user-guide/rules/list/tag-req-attr
 
-С учетом:
+## true
 
 ```json
 'htmlacademy/tag-req-attr': [
   true, {
     'input': [
       {
-        name: 'name',
-        ignore: {
-          'type': 'hidden'
-        }
+        name: 'name'
       },
     ],
     // Другие элементы...
@@ -58,4 +55,35 @@
 
 ```html
 <img alt="Picture of a cute cat" src="https://www.google.com/url?sa=i&source=images&cd=&cad=rja&uact=8&ved=2ahUKEwiHzdu5n4ThAhXOxYUKHebmDXoQjRx6BAgBEAU&url=https%3A%2F%2Fimgur.com%2Fgallery%2FHzG2YW8&psig=AOvVaw3w5Zu0oMuDZy83zsfn0NMU&ust=1552742695628256">
+```
+
+## ignore
+
+Поле `ignore` позволяет игнорировать атрибуты в зависимости от их значений.
+
+```json
+'htmlacademy/tag-req-attr': [
+  'ignore', {
+    'input': [
+      {
+        name: 'name',
+        ignore: {
+          type: 'submit'
+        }
+      },
+    ],
+]
+```
+
+Нарушениями считаются следующие модели:
+
+```html
+<input name="name" type="submit">
+```
+
+Следующие детали **не** считаются нарушениями:
+
+Если у элемента `input` атрибут `type` имеет значение `submit`, то атрибут `name` не обязателен.
+```html
+<input type="submit" value="Submit">
 ```

--- a/rules/tag-req-attr/README.md
+++ b/rules/tag-req-attr/README.md
@@ -1,0 +1,61 @@
+# htmlacademy/tag-req-attr
+
+Если установлено, указанные атрибуты должны присутствовать в указанном теге.
+
+Форк: https://linthtml.vercel.app/user-guide/rules/list/tag-req-attr
+
+С учетом:
+
+```json
+'htmlacademy/tag-req-attr': [
+  true, {
+    'input': [
+      {
+        name: 'name',
+        ignore: {
+          'type': 'hidden'
+        }
+      },
+    ],
+    // Другие элементы...
+  },
+]
+```
+
+```json
+{
+  "tag-req-attr": [
+    true,
+    {
+      "img": [
+        {
+          "name": "src"
+        },
+        {
+          "name": "alt"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Нарушениями считаются следующие модели:
+
+```html
+<img/>
+```
+
+```html
+<img src="link"/>
+```
+
+```html
+<img alt="No image">
+```
+
+Следующие детали не считаются нарушениями:
+
+```html
+<img alt="Picture of a cute cat" src="https://www.google.com/url?sa=i&source=images&cd=&cad=rja&uact=8&ved=2ahUKEwiHzdu5n4ThAhXOxYUKHebmDXoQjRx6BAgBEAU&url=https%3A%2F%2Fimgur.com%2Fgallery%2FHzG2YW8&psig=AOvVaw3w5Zu0oMuDZy83zsfn0NMU&ust=1552742695628256">
+```

--- a/rules/tag-req-attr/README.md
+++ b/rules/tag-req-attr/README.md
@@ -62,17 +62,21 @@
 Поле `ignore` позволяет игнорировать атрибуты в зависимости от их значений.
 
 ```json
-'htmlacademy/tag-req-attr': [
-  true,
-  'input': [
+{
+  'htmlacademy/tag-req-attr': [
+    true,
     {
-      name: 'name',
-      ignore: {
-        type: 'submit'
-      }
-    },
-  ],
-]
+      'input': [
+        {
+          name: 'name',
+          ignore: {
+            'type': 'submit'
+          }
+        }
+      ]
+    }
+  ]
+}
 ```
 
 Нарушениями считаются следующие модели:

--- a/rules/tag-req-attr/index.js
+++ b/rules/tag-req-attr/index.js
@@ -1,6 +1,37 @@
 'use strict';
 // eslint-disable-next-line camelcase
-const { is_tag_node, has_non_empty_attribute, has_attribute } = require('@linthtml/dom-utils');
+const { is_tag_node, has_non_empty_attribute, has_attribute, attribute_value } = require('@linthtml/dom-utils');
+const checkAttributes = (node, requiredAttributes, report) => {
+  requiredAttributes.forEach(({ name, allowEmpty, ignore }) => {
+    allowEmpty = typeof allowEmpty === 'undefined' ? false : allowEmpty;
+    if (ignore) {
+      let shouldIgnore = false;
+      for (const key in ignore) {
+        if (has_attribute(node, key) && attribute_value(node, key).chars === ignore[key]) {
+          shouldIgnore = true;
+          break;
+        }
+      }
+      if (shouldIgnore) {
+        return;
+      }
+    }
+
+    if (!has_attribute(node, name) || !has_non_empty_attribute(node, name, allowEmpty)) {
+      report({
+        code: 'E057',
+        position: node.open.loc,
+        meta: {
+          data: {
+            attribute: name,
+            tag: node.name
+          }
+        }
+      });
+    }
+  });
+};
+
 
 module.exports = {
   name: 'htmlacademy/tag-req-attr',
@@ -12,23 +43,7 @@ module.exports = {
         if (Object.hasOwnProperty.call(rule_config, tagName) && tagName === node.name) { // Ensured property belongs to object
           // eslint-disable-next-line camelcase
           const requiredAttributes = rule_config[tagName];
-
-          requiredAttributes.forEach(({ name, allowEmpty }) => {
-            allowEmpty = typeof allowEmpty === 'undefined' ? false : allowEmpty;
-
-            if (!has_attribute(node, name) || !has_non_empty_attribute(node, name, allowEmpty)) {
-              report({
-                code: 'E057',
-                position: node.open.loc,
-                meta: {
-                  data: {
-                    attribute: name,
-                    tag: node.name
-                  }
-                }
-              });
-            }
-          });
+          checkAttributes(node, requiredAttributes, report);
         }
       }
     }

--- a/rules/tag-req-attr/index.js
+++ b/rules/tag-req-attr/index.js
@@ -1,0 +1,36 @@
+'use strict';
+// eslint-disable-next-line camelcase
+const { is_tag_node, has_non_empty_attribute, has_attribute } = require('@linthtml/dom-utils');
+
+module.exports = {
+  name: 'htmlacademy/tag-req-attr',
+  // eslint-disable-next-line camelcase
+  lint(node, rule_config, { report }) {
+    if (is_tag_node(node)) {
+      // eslint-disable-next-line camelcase
+      for (const tagName in rule_config) {
+        if (Object.hasOwnProperty.call(rule_config, tagName) && tagName === node.name) { // Ensured property belongs to object
+          // eslint-disable-next-line camelcase
+          const requiredAttributes = rule_config[tagName];
+
+          requiredAttributes.forEach(({ name, allowEmpty }) => {
+            allowEmpty = typeof allowEmpty === 'undefined' ? false : allowEmpty;
+
+            if (!has_attribute(node, name) || !has_non_empty_attribute(node, name, allowEmpty)) {
+              report({
+                code: 'E057',
+                position: node.open.loc,
+                meta: {
+                  data: {
+                    attribute: name,
+                    tag: node.name
+                  }
+                }
+              });
+            }
+          });
+        }
+      }
+    }
+  },
+};


### PR DESCRIPTION
Closed #87 

Теперь правило `rag-req-attr` может иметь опцию `ignore`

Например
```json
{
  'htmlacademy/tag-req-attr': [
    true,
    {
      'input': [
        {
          name: 'name',
          ignore: {
            'type': 'submit'
          }
        }
      ]
    }
  ]
}
```
не будет требовать атрибута `name` для `<input>` с  `type="submit"`
