### PR TITLE
Update @linthtml/dom-utils version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.21",
       "license": "ISC",
       "devDependencies": {
-        "@linthtml/dom-utils": "0.9.5",
+        "@linthtml/dom-utils": "0.10.0",
         "eslint": "8.55.0",
         "eslint-config-htmlacademy": "10.0.1"
       }
@@ -219,10 +219,11 @@
       "dev": true
     },
     "node_modules/@linthtml/dom-utils": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@linthtml/dom-utils/-/dom-utils-0.9.5.tgz",
-      "integrity": "sha512-q7riY+zNsTJeD0IoRV+0VdlFu2Y5jxxFCtlw97espB7+LiQalvJV/o3bn27DuQ8U6KPbFeFDjkfS8DX5tD+Ggg==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@linthtml/dom-utils/-/dom-utils-0.10.0.tgz",
+      "integrity": "sha512-ojdVe6i8IPv0E/1gcjnpjNp1GCEdMvS+gs4/stHVj0yuNV369xIBOoJkXAGsMvohOee4As2oMiArRJDYaFUH1w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "domelementtype": "^2.2.0",
         "domhandler": "^4.2.2"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@linthtml/dom-utils": "0.9.5",
+    "@linthtml/dom-utils": "0.10.0",
     "eslint": "8.55.0",
     "eslint-config-htmlacademy": "10.0.1"
   }


### PR DESCRIPTION
@linthtml/dom-utils v0.10 was released some time ago.
The new version exports cjs and mjs files, so it can be used with `require` or `import`. The latest version also has atomic exports, so you can now import replace things like

```js
const { is_tag_node, has_non_empty_attribute, is_boolean_attribute } = require('@linthtml/dom-utils');
```
with
```js
const { is_tag_node, has_non_empty_attribute, is_boolean_attribute } = require('@linthtml/dom-utils/tags');
```